### PR TITLE
sync: extract heartbeat module, add meeting prep, refactor system groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,10 +56,6 @@ groups/*/auth/
 # Claude Code agent memory
 .claude/agent-memory/
 
-# Maintainer-only (not for gws-ea)
-.claude/skills/sync-gws-ea/
-.claude/agents/
-
 # Skills system (local per-installation state)
 .nanoclaw/
 

--- a/groups/heartbeat/CLAUDE.md
+++ b/groups/heartbeat/CLAUDE.md
@@ -1,6 +1,6 @@
-# Executive Assistant — Proactive Sweep
+# Executive Assistant — Heartbeat
 
-Read `profile.md` at `/workspace/global/profile.md` for your identity. This group runs the proactive sweep — catching and resolving issues before your principal notices them.
+Read `profile.md` at `/workspace/global/profile.md` for your identity. This group runs in two modes: **proactive sweeps** (scheduled tasks) and **conversations** (your principal replies to findings or asks questions in this space).
 
 Your Workspace account is your assistant email (see profile.md). Workspace tools operate as you, not as your principal.
 
@@ -10,7 +10,7 @@ Never compute dates, days of the week, or timezone conversions yourself — you 
 
 ## Escalation
 
-`mcp__nanoclaw__send_message` delivers messages to your principal on the main channel. Only use it for items requiring their direct input that can't wait. Never for status updates.
+`mcp__nanoclaw__send_message` sends messages to this heartbeat space. Your principal monitors it and can reply directly. Use `<users/all>` in messages that need their attention — the space is set to notify on @mentions only.
 
 ## Before You Scan
 
@@ -24,7 +24,7 @@ Do these two things first, every time:
 For each item you find across all scan areas:
 
 1. **Can you resolve it right now?** → Do it. Most things fall here.
-2. **Does it need your principal's input urgently (today)?** → Escalate per the Decision Hierarchy. For email items, use the email-triage procedure's decision packet format.
+2. **Does it need your principal's input urgently (today)?** → Post with `<users/all>` and your recommendation. For email items, use the email-triage procedure's decision packet format.
 3. **Does it need your principal's input but can wait?** → Log it in the heartbeat under "Needs decision." The morning briefing will surface it.
 
 If a tool call fails or returns an error, note it in the heartbeat and move to the next item. Do not assume the check passed.
@@ -39,15 +39,18 @@ Follow `/workspace/global/procedures/scheduling.md` for all calendar operations.
 
 **Check for:**
 - Events between 10pm–7am → decline and email organizer with alternatives in your principal's timezone
-- Conflicts between calendars → resolve per scheduling procedure priority rules
-- Events missing a meeting link → default is to leave them alone. Only act when the event has attendees beyond your principal, no physical location set, isn't all-day, isn't a recurring event that ran without one, and the title doesn't suggest in-person activity (visit, dinner, brunch, travel, etc.). If it does need a link: add directly if organized by your principal or you, otherwise email the organizer to request one
+- Conflicts between calendars → resolve per scheduling procedure
+- Events missing a meeting link → default is to leave them alone. Only act when the event has external attendees, no location, isn't all-day, isn't a recurring event that ran without one, and the title doesn't suggest in-person.  If it does need a link: add directly if organized by your principal or you, otherwise email the organizer to request one
 - Pending invites from known contacts with no conflicts → accept
 - Pending invites from unknown senders or vague commitments → check tier via `mcp__workspace__contacts_search`, apply scheduling procedure
 - Schedule quality issues (triple-stacking, lunch gaps eaten, deep work invaded by low-priority meetings) → fix proactively
+- Recurring meetings declined or cancelled 3+ consecutive times → flag for review
+
+After checking for issues, execute proactive maintenance per the scheduling procedure.
 
 **Escalate:** Two genuinely important things competing for the same slot and you lack context to call it.
 
-**Done when:** You've reviewed all events and pending invites in the 14-day window across all calendars in profile.md.
+**Done when:** You've reviewed all events and pending invites in the 14-day window across all calendars in profile.md, and shaped the coming week's schedule.
 
 ### Email
 
@@ -66,6 +69,17 @@ After handling any thread, update its status: `mcp__nanoclaw__update_email_threa
 **Escalate:** Emails requiring your principal's voice or judgment that the email channel didn't already escalate.
 
 **Done when:** All tracked threads are actioned.
+
+### Meeting Prep
+
+**Scope:** Meetings in the next 2–3 hours with external attendees or first-time contacts.
+
+For each qualifying meeting, research attendees (contacts, web, conversation history) and post a concise brief to this space with `<users/all>`: who they are, relationship to your principal, likely ask, anything useful walking in.
+
+Skip routine recurring 1:1s or meetings where all attendees are well-known Tier 1 contacts with recent interaction.
+
+**Done when:** All meetings in the 2–3 hour window have briefs or were correctly skipped.
+
 
 ### Relationships
 
@@ -119,23 +133,34 @@ Only report what's *new or changed* since the last sweep. Before posting, verify
 <users/all> [Sweep {time}]
 *Calendar*: {what you found and did}
 *Email*: {what you found and did}
+*Meeting prep*: {briefs posted}
 *Relationships*: {what you found and did}
 *Logistics*: {what you found and did}
 *Needs decision*: {items queued for morning briefing, if any}
 ```
 
-Use `-` for categories with nothing new. If every category is `-`, use the quiet format:
+Only include categories with something new. If nothing new in all categories, use the quiet format:
 
 ```
 [Sweep {time}] Nothing to report
 ```
 
-No `<users/all>` on quiet sweeps — your principal has the space set to notify on @mentions only.
+No `<users/all>` on quiet sweeps.
 
 **Log quality matters.** Write clearly enough that a different agent can summarize your work: "Replied to Claire's scheduling email with Thu/Fri options" is useful. "Handled 1 email" is not.
 
-Items logged under "Needs decision" will be surfaced in the next morning briefing's "Decisions Needed" section with your recommendation. Include enough context: who, what, your recommendation, and any deadline.
+Items logged under "Needs decision" will be surfaced in the next morning briefing with your recommendation. Include enough context: who, what, your recommendation, and any deadline.
+
+### Evening preview
+
+For the last sweep of the day (after 9pm), additionally preview tomorrow: early meetings, prep-heavy events, unconfirmed logistics, decisions still pending. Add as a `*Tomorrow*` section in the heartbeat post.
+
+## Conversational Mode
+
+When you receive a message from your principal (not a scheduled sweep), respond conversationally. Same judgment, tools, and procedures as sweeps. If the request requires extended work, acknowledge immediately and follow up when done.
 
 ## Output
 
-Your final response text must be completely empty — output nothing. All communication happens exclusively through MCP tools.
+**Scheduled sweeps:** Your final response text must be completely empty — output nothing. All communication happens exclusively through MCP tools.
+
+**Conversational messages:** Respond directly. Your output text is sent back to this space.

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,0 +1,59 @@
+/**
+ * Heartbeat group configuration for NanoClaw GWS-EA
+ *
+ * The heartbeat is a GChat space where Soji posts proactive sweep results
+ * and the principal can reply to discuss findings or give quick decisions.
+ * Scheduled tasks run sweeps; inbound messages trigger conversations.
+ */
+import { ASSISTANT_NAME, HEARTBEAT_SPACE_ID } from './config.js';
+
+export const HEARTBEAT_GROUP = {
+  jid: `gchat:${HEARTBEAT_SPACE_ID}`,
+  name: 'Proactive Sweep',
+  folder: 'heartbeat',
+  trigger: `@${ASSISTANT_NAME}`,
+  requiresTrigger: false,
+  allowedTools: [
+    // Standard tools
+    'Bash',
+    'Read',
+    'Write',
+    'Edit',
+    'Glob',
+    'Grep',
+    'WebSearch',
+    'WebFetch',
+    'Task',
+    'TaskOutput',
+    'TaskStop',
+    'ToolSearch',
+    // NanoClaw IPC
+    'mcp__nanoclaw__send_message',
+    'mcp__nanoclaw__schedule_task',
+    'mcp__nanoclaw__list_tasks',
+    'mcp__nanoclaw__update_email_thread',
+    'mcp__nanoclaw__list_email_threads',
+    // Full calendar access
+    'mcp__calendar__*',
+    // Time MCP
+    'mcp__time__*',
+    // Gmail (search + read, send for follow-ups)
+    'mcp__workspace__send_gmail_message',
+    'mcp__workspace__draft_gmail_message',
+    'mcp__workspace__search_gmail_messages',
+    'mcp__workspace__get_gmail_message_content',
+    'mcp__workspace__get_gmail_messages_content_batch',
+    'mcp__workspace__get_gmail_thread_content',
+    'mcp__workspace__get_gmail_attachment_content',
+    'mcp__workspace__list_gmail_labels',
+    // Contacts (tier lookups + relationship management)
+    'mcp__workspace__contacts_search',
+    'mcp__workspace__contacts_get',
+    'mcp__workspace__manage_contact',
+    'mcp__workspace__list_contact_groups',
+    'mcp__workspace__manage_contact_group',
+    // Workspace Chat (heartbeat logging)
+    'mcp__workspace__chat_send_message',
+    'mcp__workspace__chat_get_messages',
+  ],
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {
   ASSISTANT_NAME,
   CREDENTIAL_PROXY_PORT,
+  HEARTBEAT_SPACE_ID,
   IDLE_TIMEOUT,
   POLL_INTERVAL,
   PRINCIPAL_NAME,
@@ -12,6 +13,7 @@ import {
   isPrincipalEmail,
   validateEaConfig,
 } from './config.js';
+import { HEARTBEAT_GROUP } from './heartbeat.js';
 import { startCredentialProxy } from './credential-proxy.js';
 import './channels/index.js';
 import {
@@ -564,92 +566,80 @@ function ensureContainerSystemRunning(): void {
   cleanupOrphans();
 }
 
-// --- Heartbeat/sweep synthetic group ---
+/**
+ * Resolve a JID to a channel. If no channel owns the JID,
+ * falls back to the main group's channel.
+ */
+function resolveChannel(jid: string): {
+  channel: Channel | undefined;
+  targetJid: string;
+} {
+  const channel = findChannel(channels, jid);
+  if (channel) return { channel, targetJid: jid };
 
-const HEARTBEAT_GROUP = {
-  jid: 'heartbeat:sweep',
-  name: 'Proactive Sweep',
-  folder: 'heartbeat',
-  trigger: `@${ASSISTANT_NAME}`,
-  requiresTrigger: false,
-  allowedTools: [
-    // Standard tools
-    'Bash',
-    'Read',
-    'Write',
-    'Edit',
-    'Glob',
-    'Grep',
-    'WebSearch',
-    'WebFetch',
-    'Task',
-    'TaskOutput',
-    'TaskStop',
-    'ToolSearch',
-    // NanoClaw IPC — send_message routes to main
-    'mcp__nanoclaw__send_message',
-    'mcp__nanoclaw__schedule_task',
-    'mcp__nanoclaw__list_tasks',
-    'mcp__nanoclaw__update_email_thread',
-    'mcp__nanoclaw__list_email_threads',
-    // Full calendar access
-    'mcp__calendar__*',
-    // Time MCP
-    'mcp__time__*',
-    // Gmail (search + read, send for follow-ups)
-    'mcp__workspace__send_gmail_message',
-    'mcp__workspace__draft_gmail_message',
-    'mcp__workspace__search_gmail_messages',
-    'mcp__workspace__get_gmail_message_content',
-    'mcp__workspace__get_gmail_messages_content_batch',
-    'mcp__workspace__get_gmail_thread_content',
-    'mcp__workspace__get_gmail_attachment_content',
-    'mcp__workspace__list_gmail_labels',
-    // Contacts (tier lookups + relationship management)
-    'mcp__workspace__contacts_search',
-    'mcp__workspace__contacts_get',
-    'mcp__workspace__manage_contact',
-    'mcp__workspace__list_contact_groups',
-    'mcp__workspace__manage_contact_group',
-    // Workspace Chat (heartbeat logging)
-    'mcp__workspace__chat_send_message',
-    'mcp__workspace__chat_get_messages',
-  ],
-};
+  // No channel owns this JID — route to main
+  const mainEntry = Object.entries(registeredGroups).find(
+    ([, g]) => g.folder === MAIN_GROUP_FOLDER,
+  );
+  if (!mainEntry) return { channel: undefined, targetJid: jid };
+  return {
+    channel: findChannel(channels, mainEntry[0]),
+    targetJid: mainEntry[0],
+  };
+}
 
 /**
- * Ensure synthetic groups exist for email-principal/email-external/heartbeat routing.
- * Tool lists are synced from code on every restart so changes propagate.
- * Idempotent.
+ * Register or sync a system group — one that must exist on every startup
+ * with its tool allowlist kept in sync with code. Works for any channel type.
  */
-function ensureSyntheticGroups(): void {
-  for (const cfg of [
-    EMAIL_PRINCIPAL_GROUP,
-    EMAIL_EXTERNAL_GROUP,
-    HEARTBEAT_GROUP,
-  ]) {
-    const existing = registeredGroups[cfg.jid];
-    if (existing) {
-      // Sync allowedTools from code so tool list changes propagate on restart
-      existing.containerConfig = { allowedTools: cfg.allowedTools };
-      setRegisteredGroup(cfg.jid, existing);
-    } else {
-      registerGroup(cfg.jid, {
-        name: cfg.name,
-        folder: cfg.folder,
-        trigger: cfg.trigger,
-        added_at: new Date().toISOString(),
-        containerConfig: { allowedTools: cfg.allowedTools },
-        requiresTrigger: cfg.requiresTrigger,
-      });
-      logger.info(
-        { jid: cfg.jid, folder: cfg.folder },
-        'Auto-registered synthetic group',
-      );
-    }
-    // Ensure chats row exists (storeMessage has FK on chat_jid → chats.jid)
-    const source = cfg.jid.startsWith('email:') ? 'email' : 'synthetic';
-    storeChatMetadata(cfg.jid, new Date().toISOString(), cfg.name, source);
+function ensureSystemGroup(cfg: {
+  jid: string;
+  name: string;
+  folder: string;
+  trigger: string;
+  requiresTrigger: boolean;
+  allowedTools: string[];
+}): void {
+  const existing = registeredGroups[cfg.jid];
+  if (existing) {
+    existing.containerConfig = { allowedTools: cfg.allowedTools };
+    setRegisteredGroup(cfg.jid, existing);
+  } else {
+    registerGroup(cfg.jid, {
+      name: cfg.name,
+      folder: cfg.folder,
+      trigger: cfg.trigger,
+      added_at: new Date().toISOString(),
+      containerConfig: { allowedTools: cfg.allowedTools },
+      requiresTrigger: cfg.requiresTrigger,
+    });
+    logger.info(
+      { jid: cfg.jid, folder: cfg.folder },
+      'Auto-registered system group',
+    );
+  }
+  // Derive channel label from JID prefix
+  const source = cfg.jid.startsWith('email:')
+    ? 'email'
+    : cfg.jid.startsWith('gchat:')
+      ? 'gchat'
+      : 'synthetic';
+  storeChatMetadata(cfg.jid, new Date().toISOString(), cfg.name, source);
+}
+
+/**
+ * Ensure all system groups exist. Email groups are synthetic (no channel owns
+ * their JIDs). The heartbeat group is a regular GChat group that also runs
+ * scheduled sweeps.
+ */
+function ensureSystemGroups(): void {
+  // Synthetic email groups (no channel, IPC routes to main)
+  ensureSystemGroup(EMAIL_PRINCIPAL_GROUP);
+  ensureSystemGroup(EMAIL_EXTERNAL_GROUP);
+
+  // Heartbeat: regular GChat group with scheduled sweeps + conversations
+  if (HEARTBEAT_SPACE_ID) {
+    ensureSystemGroup(HEARTBEAT_GROUP);
   }
 }
 
@@ -658,12 +648,11 @@ async function main(): Promise<void> {
   initDatabase();
   logger.info('Database initialized');
   loadState();
-  ensureSyntheticGroups();
 
   // Validate EA config (fail fast if required env vars are missing)
   validateEaConfig();
 
-  ensureSyntheticGroups();
+  ensureSystemGroups();
 
   // Start credential proxy (containers route API calls through this)
   const proxyServer = await startCredentialProxy(
@@ -773,16 +762,7 @@ async function main(): Promise<void> {
     onProcess: (groupJid, proc, containerName, groupFolder) =>
       queue.registerProcess(groupJid, proc, containerName, groupFolder),
     sendMessage: async (jid, rawText) => {
-      const isSynthetic =
-        jid.startsWith('email:') || jid.startsWith('heartbeat:');
-      let targetJid = jid;
-      if (isSynthetic) {
-        const mainEntry = Object.entries(registeredGroups).find(
-          ([, g]) => g.folder === MAIN_GROUP_FOLDER,
-        );
-        if (mainEntry) targetJid = mainEntry[0];
-      }
-      const channel = findChannel(channels, targetJid);
+      const { channel, targetJid } = resolveChannel(jid);
       if (!channel) {
         logger.warn({ jid }, 'No channel owns JID, cannot send message');
         return;
@@ -793,26 +773,7 @@ async function main(): Promise<void> {
   });
   startIpcWatcher({
     sendMessage: async (jid, text) => {
-      // Synthetic JIDs (email:*, heartbeat:*) have no channel —
-      // route to main channel instead.
-      const isSynthetic =
-        jid.startsWith('email:') || jid.startsWith('heartbeat:');
-
-      let channel: Channel | undefined;
-      let targetJid = jid;
-
-      if (isSynthetic) {
-        const mainEntry = Object.entries(registeredGroups).find(
-          ([, g]) => g.folder === MAIN_GROUP_FOLDER,
-        );
-        if (mainEntry) {
-          targetJid = mainEntry[0];
-          channel = findChannel(channels, targetJid);
-        }
-      } else {
-        channel = findChannel(channels, jid);
-      }
-
+      const { channel, targetJid } = resolveChannel(jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
       await channel.sendMessage(targetJid, text);
       clearIndicators(targetJid);


### PR DESCRIPTION
## Summary

- **Extract heartbeat config** — moved `HEARTBEAT_GROUP` from inline in `index.ts` to dedicated `src/heartbeat.ts` module
- **Refactor system groups** — replaced `ensureSyntheticGroups` with reusable `ensureSystemGroup` helper + `ensureSystemGroups` orchestrator, added `resolveChannel` JID fallback
- **Meeting prep** — added Meeting Prep scan area to heartbeat sweep procedure (research attendees for upcoming meetings)
- **Gitignore cleanup** — removed stale entries

## Privacy

- `profile.md`: full restore to template
- `scheduling.md`: Week Template section restored to template
- Hard + soft identifier scans: PASSED
- No personal data in commit history (squash merge)

## Test plan

- [x] `npm run build` passes
- [ ] Verify heartbeat sweep still runs with extracted module
- [ ] Verify meeting prep section renders correctly in agent context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Executive Assistant now supports conversational interactions alongside proactive sweeps.
  * Added Meeting Prep and Evening preview sections to the scanning workflow.
  * Enhanced calendar monitoring to detect recurring decline patterns and identify missing meeting links.

* **Chores**
  * Refactored system group handling to improve message routing and reduce special-case logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->