### PR TITLE
sync: heartbeat one-way fix, identity grounding, email output

### DIFF
--- a/.claude/skills/sync-forks/SKILL.md
+++ b/.claude/skills/sync-forks/SKILL.md
@@ -325,7 +325,7 @@ If Abort:
 
 If Create PR:
 - `git push <fork> $STAGING`
-- Create PR with `gh pr create --repo $FORK_REPO --base $FORK_BRANCH --head $STAGING` with a summary of changes and privacy scan status.
+- Create PR with `gh pr create --repo $FORK_REPO --base $FORK_BRANCH --head $STAGING` with a summary of changes. Do NOT include privacy/scan details in the PR body — that's internal workflow, not public information.
 - Before submitting: scan the PR title and body for soft identifiers. Use "fork" where you'd say the private fork name.
 - Return the PR URL.
 

--- a/groups/email-principal/CLAUDE.md
+++ b/groups/email-principal/CLAUDE.md
@@ -20,4 +20,4 @@ The email-triage procedure covers thread tracking — follow it after handling e
 
 The Decision Hierarchy and email-triage procedure set the bar for when to escalate — don't add your own.
 
-Use `mcp__nanoclaw__send_message` to reach your principal. Default to silent (`<internal>`) for routine work.
+Use `mcp__nanoclaw__send_message` to reach your principal. Default to silent (`<internal>`) for routine work and response text. For example: `<internal>No response needed</internal>`

--- a/groups/heartbeat/CLAUDE.md
+++ b/groups/heartbeat/CLAUDE.md
@@ -8,10 +8,6 @@ Your Workspace account is your assistant email (see profile.md). Workspace tools
 
 Never compute dates, days of the week, or timezone conversions yourself — you will get them wrong. Use `mcp__time__*` tools for every date/time operation.
 
-## Escalation
-
-`mcp__nanoclaw__send_message` sends messages to this heartbeat space. Your principal monitors it and can reply directly. Use `<users/all>` in messages that need their attention — the space is set to notify on @mentions only.
-
 ## Before You Scan
 
 Do these two things first, every time:
@@ -40,7 +36,7 @@ Follow `/workspace/global/procedures/scheduling.md` for all calendar operations.
 **Check for:**
 - Events between 10pm–7am → decline and email organizer with alternatives in your principal's timezone
 - Conflicts between calendars → resolve per scheduling procedure
-- Events missing a meeting link → default is to leave them alone. Only act when the event has external attendees, no location, isn't all-day, isn't a recurring event that ran without one, and the title doesn't suggest in-person.  If it does need a link: add directly if organized by your principal or you, otherwise email the organizer to request one
+- Events missing a meeting link → default is to leave them alone. Only act when the event has external attendees, no location, isn't all-day, isn't a recurring event that ran without one, and the title doesn't suggest in-person. If it does need a link: add directly if organized by your principal or you, otherwise email the organizer to request one
 - Pending invites from known contacts with no conflicts → accept
 - Pending invites from unknown senders or vague commitments → check tier via `mcp__workspace__contacts_search`, apply scheduling procedure
 - Schedule quality issues (triple-stacking, lunch gaps eaten, deep work invaded by low-priority meetings) → fix proactively
@@ -154,12 +150,8 @@ Items logged under "Needs decision" will be surfaced in the next morning briefin
 
 For the last sweep of the day (after 9pm), additionally preview tomorrow: early meetings, prep-heavy events, unconfirmed logistics, decisions still pending. Add as a `*Tomorrow*` section in the heartbeat post.
 
-## Conversational Mode
+## Escalation
 
-When you receive a message from your principal (not a scheduled sweep), respond conversationally. Same judgment, tools, and procedures as sweeps. If the request requires extended work, acknowledge immediately and follow up when done.
+The Decision Hierarchy and Action Framework set the bar for when to escalate — don't add your own. Use `mcp__nanoclaw__send_message` to reach your principal when escalating.
 
-## Output
-
-**Scheduled sweeps:** Your final response text must be completely empty — output nothing. All communication happens exclusively through MCP tools.
-
-**Conversational messages:** Respond directly. Your output text is sent back to this space.
+All communication happens exclusively through MCP tools. Wrap any response text in `<internal>` tags so it is never forwarded. For example: `<internal>No response needed</internal>`

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,14 +1,12 @@
 /**
  * Heartbeat group configuration for NanoClaw GWS-EA
  *
- * The heartbeat is a GChat space where Soji posts proactive sweep results
- * and the principal can reply to discuss findings or give quick decisions.
- * Scheduled tasks run sweeps; inbound messages trigger conversations.
+ * One-way group for scheduled sweeps. Posts to GChat via workspace MCP.
  */
-import { ASSISTANT_NAME, HEARTBEAT_SPACE_ID } from './config.js';
+import { ASSISTANT_NAME } from './config.js';
 
 export const HEARTBEAT_GROUP = {
-  jid: `gchat:${HEARTBEAT_SPACE_ID}`,
+  jid: 'heartbeat:sweep',
   name: 'Proactive Sweep',
   folder: 'heartbeat',
   trigger: `@${ASSISTANT_NAME}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -633,16 +633,13 @@ function ensureSystemGroup(cfg: {
 }
 
 /**
- * Ensure all system groups exist. Email groups are synthetic (no channel owns
- * their JIDs). The heartbeat group is a regular GChat group that also runs
- * scheduled sweeps.
+ * Register system groups (email routing, heartbeat sweep).
+ * Tool allowlists are synced from code on every restart.
  */
 function ensureSystemGroups(): void {
-  // Synthetic email groups (no channel, IPC routes to main)
   ensureSystemGroup(EMAIL_PRINCIPAL_GROUP);
   ensureSystemGroup(EMAIL_EXTERNAL_GROUP);
 
-  // Heartbeat: regular GChat group with scheduled sweeps + conversations
   if (HEARTBEAT_SPACE_ID) {
     ensureSystemGroup(HEARTBEAT_GROUP);
   }


### PR DESCRIPTION
## Summary

- Revert heartbeat to one-way synthetic group, wrap output in `<internal>` tags to prevent leaking to main
- Inject profile.md into system prompt for reliable identity grounding, log when missing
- Tighten email:principal output for internal tags
- Minor sync-forks skill and agent-browser skill updates

## Files changed

- `src/heartbeat.ts` — simplified to one-way group
- `src/index.ts` — profile.md injection into system prompt
- `groups/heartbeat/CLAUDE.md` — streamlined heartbeat instructions
- `groups/email-principal/CLAUDE.md` — internal tag wrapping
- `.claude/skills/sync-forks/SKILL.md` — minor update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * PR bodies now exclude internal workflow details for clearer change summaries
  * Escalation guidance updated to clarify communication workflow

* **Refactor**
  * Heartbeat sweep system updated to use fixed system identifier instead of dynamic configuration
  * Escalation process streamlined to use explicit communication tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->