### PR TITLE
sync: heartbeat pre-sweep script, matters dedup

### DIFF
--- a/.claude/skills/add-gmail/SKILL.md
+++ b/.claude/skills/add-gmail/SKILL.md
@@ -85,11 +85,27 @@ All tests must pass (including the new Gmail tests) and build must be clean befo
 ls -la ~/.gmail-mcp/ 2>/dev/null || echo "No Gmail config found"
 ```
 
-If `credentials.json` already exists, skip to "Build and restart" below.
+If `credentials.json` already exists with real tokens (not `onecli-managed` values), skip to "Build and restart" below.
 
 ### GCP Project Setup
 
-Tell the user:
+Check if OneCLI is configured:
+
+```bash
+grep -q 'ONECLI_URL=.' .env 2>/dev/null && echo "onecli" || echo "manual"
+```
+
+**If OneCLI:** Tell the user to open `${ONECLI_URL}/connections?connect=gmail` to set up their Gmail connection. The dashboard walks them through creating a Google Cloud OAuth app and authorizing it. Ask them to let you know when done.
+
+Once the user confirms, run:
+
+```bash
+onecli apps get --provider gmail
+```
+
+Check that `config.hasCredentials` is `true` or `connection` is not null. The response `hint` field has instructions and a docs URL for what stub credential files to create under `~/.gmail-mcp/`. Follow the hint — never overwrite existing files that don't contain `onecli-managed` values.
+
+**If manual:** Tell the user:
 
 > I need you to set up Google Cloud OAuth credentials:
 >

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -712,11 +712,11 @@ server.tool(
   'update_matter',
   `Update an existing matter. Only provided fields are changed; omitted fields stay the same. Use this to update status, context, add artifacts, or link a tracking file.
 
-Statuses: active (work remains), waiting (blocked on someone/something), paused (intentionally on hold), resolved (done).`,
+Statuses: active (work remains), waiting (blocked on someone/something), escalated (waiting on the principal), paused (intentionally on hold), resolved (done).`,
   {
     matter_id: z.number().describe('The matter ID'),
     title: z.string().optional().describe('New title'),
-    status: z.enum(['active', 'waiting', 'paused', 'resolved']).optional().describe('New status'),
+    status: z.enum(['active', 'waiting', 'escalated', 'paused', 'resolved']).optional().describe('New status'),
     context: z.string().optional().describe('Updated living summary — rewrite the whole context, not append'),
     artifacts: z.array(z.object({
       type: z.enum(ARTIFACT_TYPES),

--- a/container/agent-runner/src/ipc-mcp-stdio.ts
+++ b/container/agent-runner/src/ipc-mcp-stdio.ts
@@ -692,8 +692,18 @@ Artifact types: email_thread (Gmail thread ID), calendar_event (Google Calendar 
 
     writeIpcFile(TASKS_DIR, data);
 
+    // Surface existing active/waiting matters so the agent can spot duplicates
+    const existing = readMattersSnapshot()
+      .filter((m) => m.status === 'active' || m.status === 'waiting' || m.status === 'escalated')
+      .map((m) => `- [${m.id}] ${m.title}`);
+
+    let text = `Matter created: "${args.title}"`;
+    if (existing.length > 0) {
+      text += `\n\nExisting open matters — if this overlaps one, delete this matter and use update_matter instead:\n${existing.join('\n')}`;
+    }
+
     return {
-      content: [{ type: 'text' as const, text: `Matter created: "${args.title}"` }],
+      content: [{ type: 'text' as const, text }],
     };
   },
 );
@@ -737,15 +747,17 @@ Statuses: active (work remains), waiting (blocked on someone/something), paused 
 
 server.tool(
   'list_matters',
-  'List tracked matters. By default shows active and waiting matters. Use status to filter.',
+  'List tracked matters. By default shows active, waiting, and escalated matters. Use status to filter, or "all" to include paused and resolved.',
   {
-    status: z.enum(['active', 'waiting', 'paused', 'resolved']).optional().describe('Filter by status (default: active + waiting)'),
+    status: z.enum(['active', 'waiting', 'escalated', 'paused', 'resolved', 'all']).optional().describe('Filter by status (default: active + waiting + escalated)'),
   },
   async (args) => {
     const all = readMattersSnapshot();
-    const matters = args.status
-      ? all.filter((m) => m.status === args.status)
-      : all.filter((m) => m.status === 'active' || m.status === 'waiting');
+    const matters = args.status === 'all'
+      ? all
+      : args.status
+        ? all.filter((m) => m.status === args.status)
+        : all.filter((m) => m.status === 'active' || m.status === 'waiting' || m.status === 'escalated');
 
     if (matters.length === 0) {
       return { content: [{ type: 'text' as const, text: 'No matters matching filters.' }] };

--- a/container/agent-runner/src/scripts/heartbeat-sweep.ts
+++ b/container/agent-runner/src/scripts/heartbeat-sweep.ts
@@ -1,0 +1,880 @@
+/**
+ * Heartbeat pre-sweep script
+ *
+ * Runs inside the container via the task `script` field BEFORE the agent wakes.
+ * Gathers data from Google APIs, applies deterministic rules, deduplicates
+ * against prior sweeps, and decides whether to wake the agent.
+ *
+ * Output (stdout, last line): { "wakeAgent": boolean, "data"?: SweepBrief }
+ */
+import fs from 'fs';
+import path from 'path';
+
+import { google } from 'googleapis';
+import type { calendar_v3 } from 'googleapis';
+import type { OAuth2Client } from 'google-auth-library';
+
+// ── Paths ──────────────────────────────────────────────────────────────────
+
+const WORKSPACE_MCP_DIR = '/home/node/.workspace-mcp';
+const KEYS_PATH = path.join(WORKSPACE_MCP_DIR, 'gcp-oauth.keys.json');
+const CREDS_PATH = path.join(WORKSPACE_MCP_DIR, 'credentials.json');
+const CALENDARS_CONFIG_PATH = path.join(WORKSPACE_MCP_DIR, 'calendars.json');
+const MATTERS_PATH = '/workspace/ipc/current_matters.json';
+const SWEEP_STATE_PATH = '/workspace/group/sweep_state.json';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface MatterSnapshot {
+  id: number;
+  title: string;
+  status: string;
+  artifacts: string | null;
+  context: string | null;
+  updated_at: string;
+}
+
+interface ParsedArtifact {
+  type: string;
+  id: string;
+}
+
+interface ThreadMeta {
+  thread_id: string;
+  subject: string;
+  last_message_from: string;
+  last_message_date: string;
+  message_count: number;
+}
+
+interface EventMeta {
+  event_id: string;
+  calendar_id: string;
+  summary: string;
+  start: string;
+  end: string;
+  is_all_day: boolean;
+  status: string;
+  organizer: string;
+  attendees: Array<{ email: string; responseStatus: string }>;
+  hangout_link: string | null;
+  location: string | null;
+  updated: string;
+}
+
+interface MatterBrief {
+  id: number;
+  title: string;
+  status: string;
+  context: string | null;
+  artifacts: ParsedArtifact[];
+  updated_at: string;
+  tags: string[];
+  threads: ThreadMeta[];
+  events: EventMeta[];
+}
+
+interface CalendarBrief {
+  event_id: string;
+  calendar_id: string;
+  summary: string;
+  start: string;
+  end: string;
+  status: string;
+  organizer: string;
+  attendees: Array<{ email: string; responseStatus: string }>;
+  hangout_link: string | null;
+  location: string | null;
+  tags: string[];
+  conflict_with?: string;
+}
+
+interface Failure {
+  source: string;
+  operation: string;
+  error: string;
+  target_id?: string;
+}
+
+interface SweepBrief {
+  generated_at: string;
+  is_evening_preview: boolean;
+  matters: MatterBrief[];
+  calendar: CalendarBrief[];
+  tomorrow?: CalendarBrief[];
+  failures: Failure[];
+}
+
+interface SweepState {
+  last_sweep_at: string;
+  matters: Record<string, { updated_at: string; reported_at: string }>;
+  calendar: Record<string, { updated: string; reported_at: string }>;
+}
+
+interface EventFilter {
+  action: 'exclude' | 'includeOnly';
+  where: string;
+  inValuesOf?: string;
+  equals?: string;
+  calendarIds?: string[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function log(msg: string): void {
+  process.stderr.write(`[heartbeat-sweep] ${msg}\n`);
+}
+
+function getNestedValue(obj: Record<string, unknown>, dotPath: string): unknown {
+  let current: unknown = obj;
+  for (const key of dotPath.split('.')) {
+    if (current == null || typeof current !== 'object') return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+function parseArtifacts(raw: string | null): ParsedArtifact[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (a: unknown): a is ParsedArtifact =>
+        typeof a === 'object' &&
+        a !== null &&
+        typeof (a as ParsedArtifact).type === 'string' &&
+        typeof (a as ParsedArtifact).id === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function getEventTime(event: calendar_v3.Schema$Event, field: 'start' | 'end'): string {
+  const dt = event[field];
+  if (!dt) return '';
+  return dt.dateTime || dt.date || '';
+}
+
+function isAllDay(event: calendar_v3.Schema$Event): boolean {
+  return !event.start?.dateTime && !!event.start?.date;
+}
+
+function getHour(isoDate: string): number {
+  return new Date(isoDate).getHours();
+}
+
+function hasExternalAttendees(
+  attendees: Array<{ email: string }>,
+  organizerEmail: string,
+  assistantEmail: string,
+): boolean {
+  const organizerDomain = organizerEmail.split('@')[1] || '';
+  if (!organizerDomain) return false;
+  return attendees.some((a) => {
+    const domain = a.email.split('@')[1] || '';
+    return domain !== organizerDomain && a.email !== assistantEmail;
+  });
+}
+
+function eventsOverlap(a: { start: string; end: string }, b: { start: string; end: string }): boolean {
+  if (!a.start || !a.end || !b.start || !b.end) return false;
+  const aStart = new Date(a.start).getTime();
+  const aEnd = new Date(a.end).getTime();
+  const bStart = new Date(b.start).getTime();
+  const bEnd = new Date(b.end).getTime();
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function toEventMeta(event: calendar_v3.Schema$Event, calendarId: string): EventMeta {
+  return {
+    event_id: event.id || '',
+    calendar_id: calendarId,
+    summary: event.summary || '(no title)',
+    start: getEventTime(event, 'start'),
+    end: getEventTime(event, 'end'),
+    is_all_day: isAllDay(event),
+    status: event.status || '',
+    organizer: event.organizer?.email || '',
+    attendees: (event.attendees || []).map((a) => ({
+      email: a.email || '',
+      responseStatus: a.responseStatus || '',
+    })),
+    hangout_link: event.hangoutLink || null,
+    location: event.location || null,
+    updated: event.updated || '',
+  };
+}
+
+function toCalendarBrief(meta: EventMeta, tags: string[], conflictWith?: string): CalendarBrief {
+  return {
+    event_id: meta.event_id,
+    calendar_id: meta.calendar_id,
+    summary: meta.summary,
+    start: meta.start,
+    end: meta.end,
+    status: meta.status,
+    organizer: meta.organizer,
+    attendees: meta.attendees,
+    hangout_link: meta.hangout_link,
+    location: meta.location,
+    tags,
+    ...(conflictWith && { conflict_with: conflictWith }),
+  };
+}
+
+// ── OAuth2 Client ──────────────────────────────────────────────────────────
+
+function createOAuth2Client(): OAuth2Client {
+  const keys = JSON.parse(fs.readFileSync(KEYS_PATH, 'utf-8'));
+  const credsFile = JSON.parse(fs.readFileSync(CREDS_PATH, 'utf-8'));
+  const creds = credsFile.normal || credsFile;
+
+  const clientConfig = keys.installed || keys.web;
+  const oauth2Client = new google.auth.OAuth2(
+    clientConfig.client_id,
+    clientConfig.client_secret,
+    clientConfig.redirect_uris?.[0],
+  );
+
+  oauth2Client.setCredentials({
+    access_token: creds.access_token,
+    refresh_token: creds.refresh_token,
+    expiry_date: creds.expiry_date,
+  });
+
+  // Persist refreshed tokens back to disk
+  oauth2Client.on('tokens', (tokens) => {
+    const existing = JSON.parse(fs.readFileSync(CREDS_PATH, 'utf-8'));
+    const target = existing.normal || existing;
+    if (tokens.access_token) target.access_token = tokens.access_token;
+    if (tokens.refresh_token) target.refresh_token = tokens.refresh_token;
+    if (tokens.expiry_date) target.expiry_date = tokens.expiry_date;
+    fs.writeFileSync(CREDS_PATH, JSON.stringify(existing, null, 2));
+  });
+
+  return oauth2Client;
+}
+
+async function getAssistantEmail(oauth2Client: OAuth2Client): Promise<string> {
+  const { token } = await oauth2Client.getAccessToken();
+  if (!token) throw new Error('No access token available');
+  const tokenInfo = await oauth2Client.getTokenInfo(token);
+  return tokenInfo.email || '';
+}
+
+// ── Event Filters ──────────────────────────────────────────────────────────
+
+function loadEventFilters(): EventFilter[] {
+  if (!fs.existsSync(CALENDARS_CONFIG_PATH)) return [];
+  try {
+    const config = JSON.parse(fs.readFileSync(CALENDARS_CONFIG_PATH, 'utf-8'));
+    return config.eventFilters || [];
+  } catch {
+    return [];
+  }
+}
+
+function applyEventFilters(
+  events: Array<{ event: calendar_v3.Schema$Event; calendarId: string }>,
+  filters: EventFilter[],
+): Array<{ event: calendar_v3.Schema$Event; calendarId: string }> {
+  let result = events;
+
+  for (const filter of filters) {
+    if (filter.action !== 'exclude') continue;
+
+    if (filter.inValuesOf) {
+      // Cross-event filter: collect all values at inValuesOf path, exclude events whose
+      // 'where' field matches any of them
+      const valueSet = new Set<string>();
+      for (const { event } of result) {
+        const val = getNestedValue(event as unknown as Record<string, unknown>, filter.inValuesOf);
+        if (typeof val === 'string') valueSet.add(val);
+      }
+      result = result.filter(({ event }) => {
+        const fieldVal = getNestedValue(event as unknown as Record<string, unknown>, filter.where);
+        return typeof fieldVal !== 'string' || !valueSet.has(fieldVal);
+      });
+    } else if (filter.equals !== undefined) {
+      result = result.filter(({ event, calendarId }) => {
+        if (filter.calendarIds && !filter.calendarIds.includes(calendarId)) return true;
+        const fieldVal = getNestedValue(event as unknown as Record<string, unknown>, filter.where);
+        return fieldVal !== filter.equals;
+      });
+    }
+  }
+
+  return result;
+}
+
+// ── Sweep State ────────────────────────────────────────────────────────────
+
+function loadSweepState(): SweepState {
+  if (!fs.existsSync(SWEEP_STATE_PATH)) {
+    return { last_sweep_at: '', matters: {}, calendar: {} };
+  }
+  try {
+    return JSON.parse(fs.readFileSync(SWEEP_STATE_PATH, 'utf-8'));
+  } catch {
+    return { last_sweep_at: '', matters: {}, calendar: {} };
+  }
+}
+
+function saveSweepState(state: SweepState): void {
+  fs.writeFileSync(SWEEP_STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+// ── Data Gathering ─────────────────────────────────────────────────────────
+
+interface CalendarInfo {
+  id: string;
+  summary: string;
+  accessRole: string;
+}
+
+async function discoverCalendars(
+  calendarClient: calendar_v3.Calendar,
+): Promise<CalendarInfo[]> {
+  const res = await calendarClient.calendarList.list({ maxResults: 100 });
+  return (res.data.items || [])
+    .filter((c) => c.accessRole && ['owner', 'writer', 'reader', 'freeBusyReader'].includes(c.accessRole))
+    .map((c) => ({ id: c.id || '', summary: c.summary || '', accessRole: c.accessRole || '' }));
+}
+
+async function fetchCalendarEvents(
+  calendarClient: calendar_v3.Calendar,
+  calendarId: string,
+  timeMin: string,
+  timeMax: string,
+): Promise<calendar_v3.Schema$Event[]> {
+  const events: calendar_v3.Schema$Event[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const res = await calendarClient.events.list({
+      calendarId,
+      timeMin,
+      timeMax,
+      singleEvents: true,
+      orderBy: 'startTime',
+      maxResults: 250,
+      pageToken,
+    });
+    events.push(...(res.data.items || []));
+    pageToken = res.data.nextPageToken || undefined;
+  } while (pageToken);
+
+  return events;
+}
+
+async function fetchThreadMeta(
+  gmail: ReturnType<typeof google.gmail>,
+  threadId: string,
+): Promise<ThreadMeta> {
+  const res = await gmail.users.threads.get({
+    userId: 'me',
+    id: threadId,
+    format: 'metadata',
+    metadataHeaders: ['From', 'Subject', 'Date'],
+  });
+
+  const messages = res.data.messages || [];
+  const lastMsg = messages[messages.length - 1];
+  const headers = lastMsg?.payload?.headers || [];
+
+  const getHeader = (name: string): string =>
+    headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || '';
+
+  const firstMsg = messages[0];
+  const firstHeaders = firstMsg?.payload?.headers || [];
+  const subject =
+    firstHeaders.find((h) => h.name?.toLowerCase() === 'subject')?.value || '';
+
+  return {
+    thread_id: threadId,
+    subject,
+    last_message_from: getHeader('From'),
+    last_message_date: getHeader('Date'),
+    message_count: messages.length,
+  };
+}
+
+async function fetchContacts(
+  people: ReturnType<typeof google.people>,
+): Promise<Set<string>> {
+  const emails = new Set<string>();
+  let pageToken: string | undefined;
+
+  do {
+    const res = await people.people.connections.list({
+      resourceName: 'people/me',
+      personFields: 'emailAddresses',
+      pageSize: 1000,
+      pageToken,
+    });
+    for (const person of res.data.connections || []) {
+      for (const email of person.emailAddresses || []) {
+        if (email.value) emails.add(email.value.toLowerCase());
+      }
+    }
+    pageToken = res.data.nextPageToken || undefined;
+  } while (pageToken);
+
+  return emails;
+}
+
+// ── Deterministic Rules ────────────────────────────────────────────────────
+
+function tagMatters(
+  matters: MatterBrief[],
+  assistantEmail: string,
+): void {
+  const SEVENTY_TWO_HOURS = 72 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  for (const matter of matters) {
+    if (matter.status === 'escalated' && !matter.tags.includes('skip_escalated')) {
+      matter.tags.push('skip_escalated');
+    }
+
+    // Check for stalled follow-ups: last thread message from assistant, >72h ago
+    for (const thread of matter.threads) {
+      const fromAssistant = thread.last_message_from
+        .toLowerCase()
+        .includes(assistantEmail.toLowerCase());
+      if (fromAssistant && thread.last_message_date) {
+        const msgTime = new Date(thread.last_message_date).getTime();
+        if (now - msgTime > SEVENTY_TWO_HOURS) {
+          matter.tags.push('stalled_followup');
+        }
+      }
+    }
+  }
+}
+
+function tagCalendarEvents(
+  events: EventMeta[],
+  contactEmails: Set<string>,
+  assistantEmail: string,
+  freeBusyCalendarIds: Set<string>,
+): Array<{ meta: EventMeta; tags: string[]; conflictWith?: string }> {
+  const tagged: Array<{ meta: EventMeta; tags: string[]; conflictWith?: string }> = [];
+
+  for (const meta of events) {
+    const tags: string[] = [];
+    const isFreeBusy = freeBusyCalendarIds.has(meta.calendar_id);
+
+    // FreeBusyReader events only participate in conflict detection (below),
+    // they don't get individual tags since we can't see their details.
+    if (!meta.is_all_day && !isFreeBusy) {
+      // Late night: 10pm-7am
+      const hour = getHour(meta.start);
+      if (hour >= 22 || hour < 7) {
+        tags.push('late_night');
+      }
+
+      // Missing meeting link
+      if (
+        !meta.hangout_link &&
+        !meta.location &&
+        meta.attendees.length > 0 &&
+        hasExternalAttendees(meta.attendees, meta.organizer, assistantEmail)
+      ) {
+        tags.push('maybe_missing_link');
+      }
+
+      // Pending invites
+      if (meta.status === 'tentative' || meta.attendees.some(
+        (a) => a.email === assistantEmail && a.responseStatus === 'needsAction',
+      )) {
+        const organizerInContacts = contactEmails.has(meta.organizer.toLowerCase());
+        if (organizerInContacts) {
+          tags.push('safe_to_accept');
+        } else {
+          tags.push('needs_review');
+        }
+      }
+
+      // Meeting prep: next 2-3 hours with external attendees
+      const startMs = new Date(meta.start).getTime();
+      const hoursOut = (startMs - Date.now()) / (60 * 60 * 1000);
+      if (hoursOut > 0 && hoursOut <= 3 &&
+          hasExternalAttendees(meta.attendees, meta.organizer, assistantEmail)) {
+        tags.push('needs_prep');
+      }
+    }
+
+    tagged.push({ meta, tags });
+  }
+
+  // Conflicts: check all pairs across different calendars.
+  // FreeBusyReader events participate as time blocks but don't get tagged —
+  // only the full-access side gets the conflict tag.
+  for (let i = 0; i < tagged.length; i++) {
+    for (let j = i + 1; j < tagged.length; j++) {
+      const a = tagged[i];
+      const b = tagged[j];
+      if (a.meta.is_all_day || b.meta.is_all_day) continue;
+      if (a.meta.calendar_id === b.meta.calendar_id) continue;
+      if (eventsOverlap(a.meta, b.meta)) {
+        const aIsFreeBusy = freeBusyCalendarIds.has(a.meta.calendar_id);
+        const bIsFreeBusy = freeBusyCalendarIds.has(b.meta.calendar_id);
+        if (!aIsFreeBusy && !a.tags.includes('conflict')) {
+          a.tags.push('conflict');
+          a.conflictWith = b.meta.event_id;
+        }
+        if (!bIsFreeBusy && !b.tags.includes('conflict')) {
+          b.tags.push('conflict');
+          b.conflictWith = a.meta.event_id;
+        }
+      }
+    }
+  }
+
+  // Conflicts override safe_to_accept
+  for (const t of tagged) {
+    const safeIdx = t.tags.indexOf('safe_to_accept');
+    if (safeIdx !== -1 && t.tags.includes('conflict')) {
+      t.tags.splice(safeIdx, 1);
+    }
+  }
+
+  // Triple-stacked: 3+ events in same 1-hour slot.
+  // FreeBusy events count toward the total but don't get tagged.
+  const nonAllDay = tagged
+    .filter((t) => !t.meta.is_all_day)
+    .map((t) => ({ ...t, startMs: new Date(t.meta.start).getTime(), endMs: new Date(t.meta.end).getTime() }));
+  for (const t of nonAllDay) {
+    if (freeBusyCalendarIds.has(t.meta.calendar_id)) continue;
+    const overlapping = nonAllDay.filter((other) =>
+      other !== t && other.startMs < t.startMs + 3600000 && other.endMs > t.startMs,
+    );
+    if (overlapping.length >= 2 && !t.tags.includes('triple_stacked')) {
+      t.tags.push('triple_stacked');
+    }
+  }
+
+  return tagged;
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const failures: Failure[] = [];
+
+  // 1. Create OAuth2 client
+  const oauth2Client = createOAuth2Client();
+
+  // 2. Derive assistant email
+  const assistantEmail = await getAssistantEmail(oauth2Client);
+  log(`Assistant email: ${assistantEmail}`);
+
+  // 3. Read matters snapshot
+  let mattersSnapshot: MatterSnapshot[] = [];
+  if (fs.existsSync(MATTERS_PATH)) {
+    try {
+      mattersSnapshot = JSON.parse(fs.readFileSync(MATTERS_PATH, 'utf-8'));
+    } catch {
+      log('Failed to parse matters snapshot');
+    }
+  }
+
+  // 4. Load sweep state
+  const prevState = loadSweepState();
+
+  // 5. Check evening preview (hour === 21 in local TZ)
+  const localHour = parseInt(
+    new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      hour12: false,
+      timeZone: process.env.TZ || 'UTC',
+    }).format(now),
+    10,
+  );
+  const isEveningPreview = localHour === 21;
+
+  // ── Gather data in parallel ──────────────────────────────────────────
+
+  const calendarClient = google.calendar({ version: 'v3', auth: oauth2Client });
+  const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+  const people = google.people({ version: 'v1', auth: oauth2Client });
+
+  // ── Gather data in parallel ──────────────────────────────────────────
+  //
+  // Phase 1: calendar discovery + contacts (independent)
+  // Phase 2: bulk calendar events + matter thread fetches (need calendars)
+  // Matter-linked events are looked up from bulk results, no extra API calls.
+
+  const calendarDiscoveryPromise = discoverCalendars(calendarClient).catch((err) => {
+    failures.push({
+      source: 'calendar',
+      operation: 'calendarList.list',
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [] as CalendarInfo[];
+  });
+
+  const contactsPromise = fetchContacts(people).catch((err) => {
+    failures.push({
+      source: 'contacts',
+      operation: 'connections.list',
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Set<string>();
+  });
+
+  // Parse matter artifacts and build thread fetch list
+  const matterBriefs: MatterBrief[] = [];
+  const matterById = new Map<number, MatterBrief>();
+  const threadFetches: Array<{ matterId: number; threadId: string }> = [];
+  const matterEventIds: Array<{ matterId: number; eventId: string }> = [];
+
+  for (const m of mattersSnapshot) {
+    const artifacts = parseArtifacts(m.artifacts);
+    const brief: MatterBrief = {
+      id: m.id,
+      title: m.title,
+      status: m.status,
+      context: m.context,
+      artifacts,
+      updated_at: m.updated_at,
+      tags: [],
+      threads: [],
+      events: [],
+    };
+
+    // Check if this escalated matter is unchanged — skip fetching
+    const stateKey = String(m.id);
+    if (
+      m.status === 'escalated' &&
+      prevState.matters[stateKey]?.updated_at === m.updated_at
+    ) {
+      brief.tags.push('skip_escalated');
+      matterBriefs.push(brief);
+      matterById.set(m.id, brief);
+      continue;
+    }
+
+    for (const a of artifacts) {
+      if (a.type === 'email_thread') threadFetches.push({ matterId: m.id, threadId: a.id });
+      if (a.type === 'calendar_event') matterEventIds.push({ matterId: m.id, eventId: a.id });
+    }
+
+    matterBriefs.push(brief);
+    matterById.set(m.id, brief);
+  }
+
+  // Fetch bulk calendar events and threads in parallel
+  const calendars = await calendarDiscoveryPromise;
+  const sevenDaysFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  const [calendarFetchResults, threadResults] = await Promise.all([
+    // Bulk calendar events across all calendars
+    Promise.all(
+      calendars.map(async (cal) => {
+        try {
+          const events = await fetchCalendarEvents(
+            calendarClient,
+            cal.id,
+            nowIso,
+            sevenDaysFromNow.toISOString(),
+          );
+          return events.map((e) => ({ event: e, calendarId: cal.id }));
+        } catch (err) {
+          failures.push({
+            source: 'calendar',
+            operation: 'events.list',
+            error: err instanceof Error ? err.message : String(err),
+            target_id: cal.id,
+          });
+          return [];
+        }
+      }),
+    ),
+    // Thread fetches for matters
+    Promise.all(
+      threadFetches.map(async ({ matterId, threadId }) => {
+        try {
+          const meta = await fetchThreadMeta(gmail, threadId);
+          return { matterId, meta };
+        } catch (err) {
+          failures.push({
+            source: 'gmail',
+            operation: 'threads.get',
+            error: err instanceof Error ? err.message : String(err),
+            target_id: threadId,
+          });
+          return null;
+        }
+      }),
+    ),
+  ]);
+
+  // Build event ID → EventMeta map from bulk results
+  const allRawEvents: Array<{ event: calendar_v3.Schema$Event; calendarId: string }> = [];
+  for (const batch of calendarFetchResults) {
+    allRawEvents.push(...batch);
+  }
+
+  const bulkEventMap = new Map<string, EventMeta>();
+  for (const { event, calendarId } of allRawEvents) {
+    if (event.id) bulkEventMap.set(event.id, toEventMeta(event, calendarId));
+  }
+
+  // Attach threads to matters
+  for (const result of threadResults) {
+    if (!result) continue;
+    const brief = matterById.get(result.matterId);
+    if (brief) brief.threads.push(result.meta);
+  }
+
+  // Attach events to matters — look up from bulk results (no extra API calls)
+  for (const { matterId, eventId } of matterEventIds) {
+    const meta = bulkEventMap.get(eventId);
+    if (meta) {
+      const brief = matterById.get(matterId);
+      if (brief) brief.events.push(meta);
+    } else {
+      failures.push({
+        source: 'calendar',
+        operation: 'events.get',
+        error: 'Event not found in 7-day window',
+        target_id: eventId,
+      });
+    }
+  }
+
+  // Tag matters
+  tagMatters(matterBriefs, assistantEmail);
+
+  // Apply event filters from calendars.json
+  const filters = loadEventFilters();
+  const filteredEvents = applyEventFilters(allRawEvents, filters);
+
+  // Build set of event IDs linked to surviving (non-dropped) matters
+  const matterLinkedEventIds = new Set<string>();
+  for (const m of matterBriefs) {
+    if (m.tags.includes('skip_escalated') && prevState.matters[String(m.id)]?.updated_at === m.updated_at) {
+      continue; // Dropped matter — don't exclude its events from calendar section
+    }
+    for (const a of m.artifacts) {
+      if (a.type === 'calendar_event') matterLinkedEventIds.add(a.id);
+    }
+  }
+
+  // Convert to EventMeta, exclude matter-linked events
+  const calendarEvents: EventMeta[] = [];
+  for (const { event, calendarId } of filteredEvents) {
+    if (event.id && matterLinkedEventIds.has(event.id)) continue;
+    calendarEvents.push(toEventMeta(event, calendarId));
+  }
+
+  // Apply calendar rules
+  const contactEmails = await contactsPromise;
+  const freeBusyCalendarIds = new Set(
+    calendars.filter((c) => c.accessRole === 'freeBusyReader').map((c) => c.id),
+  );
+  const taggedCalendar = tagCalendarEvents(calendarEvents, contactEmails, assistantEmail, freeBusyCalendarIds);
+
+  // Only keep events with at least one tag (the rest are "clean" — no issues)
+  const calendarFindings = taggedCalendar.filter((t) => t.tags.length > 0);
+
+  // ── Evening preview: tomorrow's events ──────────────────────────────
+
+  let tomorrowBriefs: CalendarBrief[] | undefined;
+  if (isEveningPreview) {
+    const tomorrowStart = new Date(now);
+    tomorrowStart.setDate(tomorrowStart.getDate() + 1);
+    tomorrowStart.setHours(0, 0, 0, 0);
+    const tomorrowEnd = new Date(tomorrowStart);
+    tomorrowEnd.setDate(tomorrowEnd.getDate() + 1);
+
+    // Filter from already-fetched events (they're within the 7-day window)
+    const tomorrowEvents = filteredEvents
+      .filter(({ event }) => {
+        const start = getEventTime(event, 'start');
+        if (!start) return false;
+        const startDate = new Date(start);
+        return startDate >= tomorrowStart && startDate < tomorrowEnd;
+      })
+      .map(({ event, calendarId }) => toEventMeta(event, calendarId));
+
+    tomorrowBriefs = tomorrowEvents.map((meta) => toCalendarBrief(meta, []));
+  }
+
+  // ── Dedup against sweep state ───────────────────────────────────────
+
+  const newState: SweepState = {
+    last_sweep_at: nowIso,
+    matters: {},
+    calendar: {},
+  };
+
+  // Dedup matters
+  const survivingMatters: MatterBrief[] = [];
+  for (const m of matterBriefs) {
+    const key = String(m.id);
+    const prev = prevState.matters[key];
+
+    if (prev && prev.updated_at === m.updated_at) {
+      newState.matters[key] = prev;
+    } else {
+      survivingMatters.push(m);
+      newState.matters[key] = { updated_at: m.updated_at, reported_at: nowIso };
+    }
+  }
+
+  // Dedup calendar findings
+  const survivingCalendar: CalendarBrief[] = [];
+  for (const finding of calendarFindings) {
+    const key = `${finding.meta.calendar_id}:${finding.meta.event_id}`;
+    const prev = prevState.calendar[key];
+
+    if (prev && prev.updated === finding.meta.updated) {
+      newState.calendar[key] = prev;
+    } else {
+      survivingCalendar.push(toCalendarBrief(finding.meta, finding.tags, finding.conflictWith));
+      newState.calendar[key] = { updated: finding.meta.updated, reported_at: nowIso };
+    }
+  }
+
+  // ── Decide: wake agent or not ───────────────────────────────────────
+
+  const isQuiet =
+    survivingMatters.length === 0 &&
+    survivingCalendar.length === 0 &&
+    failures.length === 0 &&
+    !isEveningPreview;
+
+  saveSweepState(newState);
+
+  if (isQuiet) {
+    log('Quiet sweep — nothing to report');
+    console.log(JSON.stringify({ wakeAgent: false }));
+    return;
+  }
+
+  const brief: SweepBrief = {
+    generated_at: nowIso,
+    is_evening_preview: isEveningPreview,
+    matters: survivingMatters,
+    calendar: survivingCalendar,
+    ...(tomorrowBriefs && { tomorrow: tomorrowBriefs }),
+    failures,
+  };
+
+  log(
+    `Waking agent: ${survivingMatters.length} matters, ${survivingCalendar.length} calendar findings, ${failures.length} failures`,
+  );
+  console.log(JSON.stringify({ wakeAgent: true, data: brief }));
+}
+
+main().catch((err) => {
+  log(`Fatal error: ${err instanceof Error ? err.message : String(err)}`);
+  // Let the script crash — agent-runner will wake agent with full sweep as fallback
+  process.exit(1);
+});

--- a/container/agent-runner/src/scripts/heartbeat-sweep.ts
+++ b/container/agent-runner/src/scripts/heartbeat-sweep.ts
@@ -107,8 +107,8 @@ interface SweepBrief {
 
 interface SweepState {
   last_sweep_at: string;
-  matters: Record<string, { updated_at: string; reported_at: string }>;
-  calendar: Record<string, { updated: string; reported_at: string }>;
+  matters: Record<string, { updated_at: string; reported_at: string; fingerprint?: string }>;
+  calendar: Record<string, { updated: string; reported_at: string; fingerprint?: string }>;
 }
 
 interface EventFilter {
@@ -435,6 +435,9 @@ function tagMatters(
   const now = Date.now();
 
   for (const matter of matters) {
+    const isOpen = matter.status === 'active' || matter.status === 'waiting' || matter.status === 'escalated';
+    if (!isOpen) continue;
+
     if (matter.status === 'escalated' && !matter.tags.includes('skip_escalated')) {
       matter.tags.push('skip_escalated');
     }
@@ -814,31 +817,33 @@ async function main(): Promise<void> {
     calendar: {},
   };
 
-  // Dedup matters
+  // Dedup matters — fingerprint includes tags so state transitions (e.g. stalled_followup) wake the agent
   const survivingMatters: MatterBrief[] = [];
   for (const m of matterBriefs) {
     const key = String(m.id);
     const prev = prevState.matters[key];
+    const fingerprint = `${m.updated_at}|${m.tags.sort().join(',')}`;
 
-    if (prev && prev.updated_at === m.updated_at) {
+    if (prev && prev.fingerprint === fingerprint) {
       newState.matters[key] = prev;
     } else {
       survivingMatters.push(m);
-      newState.matters[key] = { updated_at: m.updated_at, reported_at: nowIso };
+      newState.matters[key] = { updated_at: m.updated_at, reported_at: nowIso, fingerprint };
     }
   }
 
-  // Dedup calendar findings
+  // Dedup calendar findings — fingerprint includes tags + conflicts
   const survivingCalendar: CalendarBrief[] = [];
   for (const finding of calendarFindings) {
     const key = `${finding.meta.calendar_id}:${finding.meta.event_id}`;
     const prev = prevState.calendar[key];
+    const fingerprint = `${finding.meta.updated}|${finding.tags.sort().join(',')}|${finding.conflictWith ?? ''}`;
 
-    if (prev && prev.updated === finding.meta.updated) {
+    if (prev && prev.fingerprint === fingerprint) {
       newState.calendar[key] = prev;
     } else {
       survivingCalendar.push(toCalendarBrief(finding.meta, finding.tags, finding.conflictWith));
-      newState.calendar[key] = { updated: finding.meta.updated, reported_at: nowIso };
+      newState.calendar[key] = { updated: finding.meta.updated, reported_at: nowIso, fingerprint };
     }
   }
 

--- a/groups/global/procedures/email-triage.md
+++ b/groups/global/procedures/email-triage.md
@@ -17,11 +17,13 @@ Every email requires a triage decision before you compose anything. Default to a
 **Before composing**, get the full picture:
 
 1. Check if this thread is linked to a matter: `find_matter(artifact_type="email_thread", artifact_id=thread_id)`. If found, read the matter's context — it may contain principal instructions, prior decisions, or actions already taken that change how (or whether) you should respond. Apply the information authority hierarchy from global CLAUDE.md.
-2. Read the full email thread (not just the latest message) to see if you or another agent already replied, and to understand the full conversation arc. Don't duplicate a reply that was already sent.
+2. Read the full email thread (not just the latest message) to understand the conversation arc and check who sent the last message.
+3. If the most recent message on the thread was sent from your assistant email and no new inbound has arrived since — stop. Do not reply, correct, improve, or follow up on your own message. Exceptions: (a) your principal explicitly instructs you to send again, or (b) a follow-up on a stale thread (>72 hours with no reply from the other party). Outside these two cases, the thread is waiting on the other party — leave it alone.
+4. Before composing a *new* outbound email (not a reply), search Gmail (`search_gmail_messages`) for recent sent messages to the same recipient on the same topic. Reply on an existing thread rather than starting a new one when the conversation is clearly related.
 
 **Principal is already in the conversation → stay out.** If your principal has replied directly on the thread, they're handling it. Don't layer on top of their voice. The only reason to step in is if you're addressed directly, asked to take over, or have concrete logistics to add that your principal didn't include. Your principal choosing to reply directly is a signal, not a gap for you to fill.
 
-**Handle without asking:**
+**Handle without asking** (subject to step 3 above — this list governs *whether to involve your principal*, not whether to send):
 - Scheduling (use the scheduling procedure — it has its own judgment for when to involve your principal)
 - Confirmations, acknowledgments, follow-ups on existing threads
 - Information requests you can answer from context, research, or calendar
@@ -39,7 +41,7 @@ When the Decision Hierarchy says to escalate, use a decision packet (see below).
 
 Adding them to the thread keeps them on future replies. Forwarding gives them the full context.
 
-**Sent something wrong?** Re-read the source procedure before correcting — the error is usually in your interpretation, not just the output. If the mistake is cosmetic, course-correct in your next natural reply rather than sending a standalone correction.
+**Sent something wrong?** Re-read the source procedure before correcting — the error is usually in your interpretation, not just the output. If the mistake is cosmetic, wait for the next inbound message on the thread and course-correct in that reply. Do not send a standalone correction — the recipient doesn't need to see you arguing with yourself.
 
 ## Threading
 
@@ -52,8 +54,6 @@ Always include `references`. When thread history is available, the references ch
 Thread history is included in the prompt when available. Only fetch thread content separately if you need the full untruncated body of a specific message.
 
 Use the provided `to` and `cc` verbatim. If you change them, note it in italics at the top of the reply: *minus xyz*, *plus abc*, *just us*, etc. **Never guess an email address** — if you don't have it, look it up in Contacts or ask.
-
-Before composing a new outbound email, search Gmail (`search_gmail_messages`) for existing threads on the same topic. Reply on an existing thread rather than starting a new one when the conversation is clearly related.
 
 ## Style
 
@@ -93,8 +93,9 @@ Own commitments made in emails. Execute now, or schedule a task for future deadl
 Update the matter that tracks this workstream:
 
 - **Thread already linked to a matter** → update the matter's context with what happened: what the email said, what you did, the outcome. Apply context hygiene — reconcile, don't append.
-- **New workstream that warrants tracking** → create a matter and link the thread as an artifact. Include enough context for the next agent to understand the situation.
-- **One-off exchange, fully handled** → no matter needed. But if in doubt, create one — a matter that turns out unnecessary is cheap; a missed workstream is expensive.
+- **Outbound email about a tracked workstream** → link the sent thread as an artifact on the existing matter (`artifact_type: "email_thread"`, `artifact_id: thread_id`). If the email was triggered by a calendar event, also link the event (`artifact_type: "calendar_event"`, `artifact_id: event_id`). This is how the next agent finds your email.
+- **New workstream** → create a matter, link the thread as an artifact, include enough context for the next agent. Default to creating — a matter that turns out unnecessary is cheap; a missed workstream is expensive.
+- **One-off exchange, fully handled, no future action** → no matter needed. But "fully handled" means nothing downstream depends on it. If in doubt, create one.
 
 ## Verification
 

--- a/groups/global/procedures/scheduling.md
+++ b/groups/global/procedures/scheduling.md
@@ -108,6 +108,10 @@ Use `mcp__time__*` tools for ALL date/time computation — resolving "next Tuesd
 7. Set your principal's `responseStatus` to `"accepted"` in the attendees list
 8. Timezone: use your principal's primary timezone
 
+## After Scheduling
+
+If this scheduling interaction is tracked by a matter, link the new calendar event as an artifact (`artifact_type: "calendar_event"`, `artifact_id: event_id`) and update the matter's context with the confirmed time, attendees, and any logistics. This is how other groups and future sweeps connect the event back to the workstream.
+
 ## Verification
 
 After creating any event, silently verify (do not send these checks to your principal):

--- a/groups/heartbeat/CLAUDE.md
+++ b/groups/heartbeat/CLAUDE.md
@@ -4,12 +4,22 @@ Read `profile.md` at `/workspace/global/profile.md` for your identity. This grou
 
 Your Workspace account is your assistant email (see profile.md). Workspace tools operate as you, not as your principal.
 
-## Before You Scan
+## Your Briefing
 
-Do these two things first, every time:
+The script output above contains pre-gathered data for this sweep:
 
-1. **Get current time.** Call `mcp__time__now`. All time references in this sweep are relative to this result.
+- `matters` — matters updated in the last hour, with linked thread/event data and deterministic tags
+- `calendar` — calendar events with issues, tagged by type (conflicts, late_night, missing links, etc.)
+- `tomorrow` — (evening sweeps only) all events tomorrow
+- `failures` — API calls that failed during data gathering
+
+Source data is inline — the script already fetched threads, events, and contacts. Don't re-fetch unless you need deeper detail for a judgment call (e.g., full email body for composing a reply). Tags tell you what the script already determined; your job is to decide what to do about each item.
+
+## Before You Act
+
+1. **Get current time.** Call `mcp__time__now`. All time references are relative to this.
 2. **Read directives.** If `/workspace/directives.md` exists, read it. Directives override scan procedures — if one says not to touch something, skip it completely.
+3. **Review the briefing data** from the script output.
 
 ## Action Framework
 
@@ -22,115 +32,82 @@ For each item you find across all scan areas:
 
 If a tool call fails or returns an error, note it in the heartbeat and move to the next item. Do not assume the check passed.
 
-## Scan Areas
+## Matters
 
-### Phase 1 — Review Changed Matters
+For each matter in the briefing:
 
-The matters snapshot (`/workspace/ipc/current_matters.json`) contains only matters updated in the last hour — these are the ones that need your attention. For each:
-
-1. **Read the matter** — status, context, artifacts, what was last done.
-2. **Fetch fresh source data** — for linked email threads, pull the full thread content. For linked calendar events, read the event from the API. Verify matter context against ground truth.
-3. **Compare** — has the thread moved since the context was last updated? Has the calendar event changed? Did you or another agent already act (check the thread for your own replies)? Is the matter context still accurate?
-4. **Reconcile** — if ground truth differs from matter context, update using the information authority hierarchy: principal's word > current system state > matter context > third-party communication.
-5. **Act or skip** — follow the Action Framework. After acting, update the matter context per context hygiene: reconcile (don't append), tag facts with source and time, prune superseded information.
-
-**Staleness checks:** For matters with approaching deadlines (<48 hours), stalled follow-ups (waiting >3 days with no reply → send a polite follow-up), or items that should have been resolved by now — act or escalate.
-
-**Consolidate** — if multiple matters cover the same workstream, move artifacts to the primary matter and delete the duplicates.
+1. **Review tags and linked data** — the script tagged matters with `skip_escalated` (already escalated, unchanged) and `stalled_followup` (last outbound >72h with no reply).
+2. **`skip_escalated`** — do not act. Only note genuinely new inbound information by updating the matter's context.
+3. **`stalled_followup`** — compose and send a polite follow-up email per the email-triage procedure (this qualifies as the >72h exception).
+4. **All other matters** — review the linked thread/event data alongside the matter's context. Apply the Action Framework.
+5. **After acting**, update the matter context per context hygiene: reconcile (don't append), tag facts with source and time, prune superseded information.
 
 Read `/workspace/global/procedures/email-triage.md` before composing any email reply.
 
-**Escalate:** Matters requiring your principal's voice or judgment that the email channel didn't already escalate.
+**Consolidate** — if multiple matters in the briefing cover the same workstream, move artifacts to the primary matter and delete the duplicates.
 
-**Done when:** All matters in the snapshot are reviewed and actioned.
+### Before sending any email about an event
 
-### Phase 2 — Calendar & Logistics
+1. `find_matter` by calendar event ID. If none exists, create one.
+2. Check the matter's context and artifacts for prior email actions on this event — another sweep or group may have already emailed about it.
+3. If no prior email, compose per email-triage procedure. Link both the calendar event and the outbound email thread as artifacts on the matter.
+4. If a prior email was already sent and no new information has arrived since, skip.
+
+Calendar-only actions (accept, decline, move, add a meeting link you control) don't need this — execute directly.
+
+### Before modifying any event
+
+1. **Check if the event is linked to a matter.** If yes, read the matter's context. If the context reflects a principal instruction (authority level 1), do not override it based on email threads or external input.
+2. **Re-read the event.** Confirm the issue still exists by reading the event from the calendar API right now. Don't modify based on what the briefing suggested — verify the calendar's current state first.
+3. **Check for user override.** If the event changed since the last sweep touched it and you didn't make that change, your principal edited it directly. Do not modify it.
+
+After acting on any event, update the linked matter's context with what you did, what changed, and why.
+
+## Calendar
+
+For each finding in the briefing:
+
+- **`late_night`** → decline; email organizer with alternatives (see before sending any email above)
+- **`conflict`** → resolve per scheduling procedure. The `conflict_with` field identifies the other event.
+- **`maybe_missing_link`** → the script flagged this because there's no meeting link, external attendees, and no location. But it could be an in-person meeting, a meal, or something that doesn't need a link. Read the event title and context to judge. If it clearly needs a virtual link: add directly if organized by your principal or you, otherwise email the organizer (see before sending any email above). If it's likely in-person or ambiguous, skip.
+- **`safe_to_accept`** → accept (organizer is a known contact, no conflicts). If the event also has a `conflict` tag, resolve the conflict first — don't blindly accept.
+- **`needs_review`** → check tier via `mcp__workspace__contacts_search`, apply scheduling procedure
+- **`triple_stacked`** → assess priorities, resolve per scheduling procedure
+- **`needs_prep`** → see Meeting Prep below.
 
 Follow `/workspace/global/procedures/scheduling.md` for all calendar operations.
 
-#### Calendar
+## Meeting Prep
 
-**Scope:** All events across all calendars listed in profile.md in the next 7 days.
-
-**Check for:**
-- Events between 10pm–7am → decline and email organizer with alternatives in your principal's timezone
-- Conflicts between calendars → resolve per scheduling procedure
-- Events missing a meeting link → add one only when: external attendees, no location set, not all-day, not a recurring event that ran fine without one, and title suggests virtual. If organized by your principal or you, add directly; otherwise email the organizer to request one. Leave all other events as-is
-- Pending invites from known contacts with no conflicts → accept
-- Pending invites from unknown senders or vague commitments → check tier via `mcp__workspace__contacts_search`, apply scheduling procedure
-- Schedule quality issues (triple-stacking, lunch gaps eaten, deep work invaded by low-priority meetings) → fix proactively
-- Recurring meetings declined or cancelled 3+ consecutive times → flag for review
-- Events needing prep, logistics, or follow-up → `find_matter` by calendar event ID. If no matter exists and the event needs action, create one. Routine events with no action needed → skip.
-
-Before modifying any event:
-
-1. **Check if the event is linked to a matter.** If yes, read the matter's context. If the context reflects a principal instruction (authority level 1), do not override it based on email threads or external input.
-2. **Re-read the event.** Confirm the issue still exists by reading the event from the calendar API right now. Don't modify based on what an email or earlier read suggested — verify the calendar's current state first.
-3. **Check for user override.** If the event changed since the last sweep touched it and you didn't make that change, your principal edited it directly. Do not modify it.
-
-After checking for issues, execute proactive maintenance per the scheduling procedure.
-
-**After acting on any event**, update the linked matter (or create one if the action warrants tracking). Record what you did, what changed, and why. This is how Phase 1 on the next sweep knows not to re-evaluate.
-
-**Escalate:** Two genuinely important things competing for the same slot and you lack context to call it.
-
-**Done when:** You've reviewed all events and pending invites in the 7-day window across all calendars in profile.md, and shaped the coming week's schedule.
-
-#### Meeting Prep
-
-**Scope:** Meetings in the next 2–3 hours with external attendees or first-time contacts.
-
-For each qualifying meeting, research attendees (contacts, web, conversation history) and post a concise brief to the heartbeat space with `<users/all>`: who they are, relationship to your principal, likely ask, anything useful walking in.
+For events tagged `needs_prep`: research attendees (contacts, web, conversation history) and post a concise brief to the heartbeat space with `<users/all>`: who they are, relationship to your principal, likely ask, anything useful walking in.
 
 Skip routine recurring 1:1s or meetings where all attendees are well-known Tier 1 contacts with recent interaction.
 
-**Done when:** All meetings in the 2–3 hour window have briefs or were correctly skipped.
+## Evening Preview
 
-#### Relationships
+If `is_evening_preview` is true in the briefing, preview tomorrow using the `tomorrow` array. Add a `*Tomorrow*` section: early meetings, prep-heavy events, unconfirmed logistics, decisions still pending.
 
-Follow `/workspace/global/procedures/relationships.md` for tier definitions and contact management rules.
+## Failures
 
-**Check for:**
-- People your principal interacted with (email or calendar) who aren't in Contacts → apply the relationships procedure threshold. If they belong, create with name, email, org, and tier. Default to Tier 3 unless signals indicate higher
-- Contacts with no tier label and no recent interaction (30 days) → assess interaction history, assign a tier or remove
-- Tier 1 contacts with no email or calendar interaction in 4+ weeks → note in heartbeat
-- Tier 2 contacts with no interaction in 12+ weeks → same
+If `failures` is non-empty, mention them briefly so your principal knows a check was incomplete. Example: "Gmail API unavailable — email matters skipped, will retry next sweep."
 
-Don't initiate outreach for stale relationships — your principal may have context outside the system. Surface the gap, act when they say to.
-
-**Done when:** Untracked contacts are created, untiered contacts are classified or removed, and stale relationships are surfaced.
-
-#### Logistics
-
-**Scope:** Events in the next 7 days.
-
-- Events needing reservations, materials, or venue confirmation → handle proactively
-- **Travel:** Events in different cities without flights, hotel, or ground transport → research options, propose to your principal
-- **Date nights** without a location or reservation → research and book something appropriate, or flag if you need your principal's preference
-
-**Done when:** All events in the 7-day window have logistics confirmed or flagged.
-
-## After Scanning
+## Posting Results
 
 Send via `mcp__workspace__chat_send_message` with your assistant email (`user_google_email` from profile.md) and `space_id` from profile.md (the heartbeat space).
 
-Only report what's *new or changed*. Before posting, verify: Did you actually check all scan areas? Does the heartbeat accurately reflect what you did, not what you planned to do?
+**One topic, one line.** When an action spans multiple categories (declining an event + emailing alternatives, or a matter that needs a decision), report it once in the most relevant category. Combine the actions into a single line — do not repeat the same topic across categories.
 
-**One topic, one line.** When an action spans multiple scan areas (declining an event + emailing alternatives, or a logistics item that needs a decision), report it once in the most relevant category. Combine the actions into a single line — do not repeat the same topic across categories.
-
-**When something happened** — start with `<users/all>` so your principal gets notified:
+**When there's something to report** — Start with `<users/all>` so your principal gets notified:
 
 ```
 <users/all> [Sweep {time}]
 *Calendar*: {what you found and did}
 *Matters*: {what changed and what you did}
 *Meeting prep*: {briefs posted}
-*Relationships*: {what you found and did}
-*Logistics*: {what you found and did}
 *Needs decision*: {items queued for morning briefing, if any}
 ```
 
-Only include categories where you acted or found something that needs your principal's attention. "Checked and found nothing" is not news — skip the category entirely. If nothing new in all categories, use the quiet format:
+Only include categories where you acted or found something that needs your principal's attention. Skip empty categories entirely. If after reviewing the briefing you find nothing worth reporting, use the quiet format:
 
 ```
 [Sweep {time}] Nothing to report
@@ -141,10 +118,6 @@ No `<users/all>` on quiet sweeps — your principal has the space set to notify 
 **Log quality matters.** Write clearly enough that a different agent can summarize your work: "Replied to Claire's scheduling email with Thu/Fri options" is useful. "Handled 1 email" is not.
 
 Items logged under "Needs decision" will be surfaced in the next morning briefing with your recommendation. Include enough context: who, what, your recommendation, and any deadline.
-
-### Evening preview
-
-For the last sweep of the day (after 9pm), additionally preview tomorrow: early meetings, prep-heavy events, unconfirmed logistics, decisions still pending. Add as a `*Tomorrow*` section in the heartbeat post.
 
 ## Escalation
 

--- a/groups/main/CLAUDE.md
+++ b/groups/main/CLAUDE.md
@@ -183,6 +183,14 @@ When your principal tells you to leave something alone, not to touch a calendar 
 
 **Directive-matter linking.** If the directive relates to an active matter, also update the matter's context to reflect the directive as authoritative truth. The directive file is the broadcast; the matter is the source of truth. They must agree. Apply context hygiene — replace the superseded information, don't append the directive alongside contradictory facts.
 
+### Corrections
+
+When your principal corrects your approach, overrides your judgment, or redirects you — append a one-line entry to `notes/corrections.md` before moving on:
+
+- `YYYY-MM-DD | what you did | what the correction was | which procedure applies`
+
+This log is input for the weekly review, not a permanent record. Record when a procedure led you to the wrong conclusion or when your judgment call was off.
+
 ### Relationships
 
 Part of your job is maintaining your principal's relationship context. Before engaging with anyone, read: `/workspace/project/groups/global/procedures/relationships.md`.
@@ -191,7 +199,7 @@ Part of your job is maintaining your principal's relationship context. Before en
 
 Main-specific procedures (read-write):
 - `procedures/morning-briefing.md` — daily chief-of-staff briefing
-- `procedures/weekly-review.md` — Friday project tracker + chief-of-staff review
+- `procedures/weekly-review.md` — Friday system review + procedure refinement
 
 Global reference material is at `/workspace/project/groups/global/`:
 - `procedures/relationships.md` — tier definitions, Google Contacts as CRM, engagement rules

--- a/groups/main/procedures/weekly-review.md
+++ b/groups/main/procedures/weekly-review.md
@@ -1,35 +1,52 @@
 # Weekly Review
 
-Friday review of key projects — matters with a `tracking_file`. These are the long-running, high-stakes workstreams that warrant a detailed weekly check-in. Routine email matters and one-off tasks are not in scope — the sweep handles those.
+Friday system review. You review how the system performed this week and propose targeted edits to procedures and instructions. Your principal decides what ships.
 
-Your principal scans this over the weekend to plan the week ahead.
+This is not a retrospective or a report. It's a procedure edit session.
 
-Use `mcp__time__*` tools for ALL date/time computation. Never calculate dates yourself.
+## Gather
 
-## Execution
+Use `mcp__time__*` tools for ALL date/time computation.
 
-1. Load all matters via `list_matters` — filter to those with a `tracking_file` (use `get_matter` to check)
-2. For each, read the tracking file for detailed context, then fetch fresh source data — pull linked email threads and read linked calendar events from the API to verify the matter context is current
-3. Update the tracking file contents with current status and blockers, and refresh the matter's context summary
-4. Compose one message with what your principal needs to see. Send via `mcp__nanoclaw__send_message`, even if everything is green
+1. **Corrections** — read `notes/corrections.md`. These are recorded instances where your principal corrected your approach during the week.
+2. **Heartbeat activity** — read heartbeat messages from the heartbeat space (profile.md) for the past 7 days via `mcp__workspace__chat_list_messages`.
+3. **Matters** — `list_matters(status: "all")`, filter to those with `updated_at` in the last 7 days. For each, `get_matter` and check the context for how it was handled — escalation patterns, resolution path, corrections recorded.
+4. **Directives** — read `notes/directives.md`. Note any that were added this week — they often signal a procedure gap (the system did something the principal had to override).
 
-## What to Surface
+## Identify
 
-In the message to your principal:
-- Stalled or blocked matters get a one-line status each — what's wrong and what you recommend
-- Healthy matters get skipped. If everything is healthy, say so
-- If a matter has been waiting or active for multiple weeks with no progress, escalate the framing — it's drifting, not just "needs attention"
-- Matters that should be resolved but aren't — surface the question
+Look for patterns, not incidents. A single correction is noise. The same type of correction twice, or multiple escalations with the same shape, is a signal.
 
-## Decisions Needed
+- Did a procedure lead to the wrong conclusion more than once?
+- Were escalations predictable from existing rules? If yes, the auto-resolve scope could be wider.
+- Were auto-resolutions overridden? If yes, the scope is too wide.
+- Did the same type of issue recur (scheduling conflicts, email tone, missing context)?
+- Were new directives added because the system acted on something it shouldn't have?
 
-Matters with status `escalated` that are still unresolved, plus any that should be escalated but weren't. Numbered, with your recommendation and deadline.
+## Propose
 
-If nothing needs a decision, skip this section entirely.
+For each pattern found, draft a specific edit:
 
-## Tone
+1. **Read the full target file** before proposing any change.
+2. **Read all related markdown files** — a change to one procedure or CLAUDE.md may conflict with another. Check cross-references.
+3. **Draft the edit**: which file, which section, what it currently says, what it should say instead.
+4. **Explain why**: what happened this week that this edit would have changed.
+5. **Verify consistency**: ensure the edit doesn't contradict instructions elsewhere. If it does, draft edits to both files.
 
-Write like a weekly staff memo, not a dashboard dump. Judgment-forward — don't just list what's overdue, say what matters and what you recommend. Terse, direct, scannable in 2 minutes.
+Edits should match the target file's existing voice and structure. No new sections unless the change genuinely warrants it. No bloat, no repetition. If the change fits as a clause in an existing rule, put it there.
+
+## Present
+
+Send via `mcp__nanoclaw__send_message`:
+
+- If patterns were found: one item per proposed change — the file, the edit, and why. Keep it scannable. Your principal replies with what to apply, what to skip, and any adjustments.
+- If nothing surfaced: exit quietly. A quiet week means the system is working. Don't manufacture observations.
+
+## After
+
+When your principal approves changes, make the edits. After editing, re-read the modified file to verify it reads coherently — the edit should look like it was always there.
+
+Once the conversation is done and all approved edits are applied, clear `notes/corrections.md`.
 
 ## Output
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3158,9 +3158,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/container-runner.ts
+++ b/src/container-runner.ts
@@ -145,6 +145,17 @@ function buildVolumeMounts(
       readonly: false,
     });
 
+    // Global memory directory (read-only for non-main)
+    // Only directory mounts are supported, not file mounts
+    const globalDir = path.join(GROUPS_DIR, 'global');
+    if (fs.existsSync(globalDir)) {
+      mounts.push({
+        hostPath: globalDir,
+        containerPath: '/workspace/global',
+        readonly: true,
+      });
+    }
+
     // Non-main groups get main's directives file so cross-group
     // overrides are visible to autonomous agents.
     const directivesFile = path.join(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1327,19 +1327,20 @@ async function main(): Promise<void> {
     onProcess: (groupJid, proc, containerName, groupFolder) =>
       queue.registerProcess(groupJid, proc, containerName, groupFolder),
     sendMessage: async (jid, rawText) => {
-      const { channel, targetJid } = resolveChannel(jid);
-      if (!channel) {
-        logger.warn({ jid }, 'No channel owns JID, cannot send message');
-        return;
-      }
+      // Only deliver response text to groups with a real channel.
+      // Synthetic groups communicate via send_message IPC instead.
+      const channel = findChannel(channels, jid);
+      if (!channel) return;
       const text = formatOutbound(rawText);
-      if (text) await channel.sendMessage(targetJid, text);
+      if (text) await channel.sendMessage(jid, text);
     },
   });
   startIpcWatcher({
-    sendMessage: async (jid, text) => {
+    sendMessage: async (jid, rawText) => {
       const { channel, targetJid } = resolveChannel(jid);
       if (!channel) throw new Error(`No channel for JID: ${jid}`);
+      const text = formatOutbound(rawText);
+      if (!text) return;
       await channel.sendMessage(targetJid, text);
       clearIndicators(targetJid);
     },
@@ -1451,8 +1452,9 @@ async function main(): Promise<void> {
     const prompt = buildEmailPrompt(email, isExternal, threadMessages);
 
     const emailTask = async (): Promise<void> => {
-      const { channel: outputChannel, targetJid: outputJid } =
-        resolveChannel(targetJid);
+      // Response text only delivered if group has a real channel.
+      // Synthetic groups (email, heartbeat) communicate via send_message IPC.
+      const outputChannel = findChannel(channels, targetJid);
 
       logger.info(
         { emailId: email.id, threadId: email.threadId, route: targetFolder },
@@ -1472,7 +1474,7 @@ async function main(): Promise<void> {
                 : JSON.stringify(result.result);
             const text = formatOutbound(raw);
             if (text && outputChannel) {
-              await outputChannel.sendMessage(outputJid, text);
+              await outputChannel.sendMessage(targetJid, text);
             }
           }
         },


### PR DESCRIPTION
## Summary

- **Heartbeat pre-sweep script** (`container/agent-runner/src/scripts/heartbeat-sweep.ts`): deterministic data gathering before agent wakes — fetches matters, calendar events, and tags issues so the agent acts on pre-computed findings instead of scanning raw APIs
- **Matters dedup**: `create_matter` now surfaces existing open matters so the agent can spot duplicates; `list_matters` adds `escalated` status and `all` filter
- **Email triage improvements**: self-reply guard (don't reply to your own last message), outbound email dedup (search before composing new threads), better correction guidance
- **Heartbeat refactor**: tag-driven sweep using script output instead of raw API scanning; structured calendar issue handling; "before sending email about an event" guard to prevent duplicate outreach
- **Weekly review rewrite**: from project-status reporting to procedure-edit sessions driven by corrections log
- **Upstream** (3 commits): dependency update, Gmail OneCLI credential mode detection

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| Container | `heartbeat-sweep.ts` (new), `ipc-mcp-stdio.ts`, `container-runner.ts`, `index.ts` | Pre-sweep script, matters dedup, section cleanup |
| Procedures | `email-triage.md`, `scheduling.md`, `heartbeat/CLAUDE.md`, `weekly-review.md` | Self-reply guard, tag-driven sweep, procedure review |
| Core | `src/index.ts` | findChannel for response delivery, rawText param |
| Groups | `main/CLAUDE.md` | Corrections log for weekly review |
| Skills | `add-gmail/SKILL.md` | OneCLI credential mode (from upstream) |
| Build | `package-lock.json` | Dependency update (from upstream) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated pre-sweep producing prioritized matter and calendar findings before waking the agent.
  * OneCLI dashboard option for Gmail setup.
  * Matter listing now surfaces escalated items and offers an "all" view.

* **Bug Fixes**
  * Prevents assistant from replying to self-authored threads.
  * Better linking of calendar events to matters.
  * Fixed container message delivery routing.

* **Documentation**
  * Updated email triage, scheduling, heartbeat, and weekly-review procedures; added a Corrections note.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->